### PR TITLE
Add support for typing.Required, NotRequired

### DIFF
--- a/dataclass_witch/__init__.py
+++ b/dataclass_witch/__init__.py
@@ -67,6 +67,7 @@ For full documentation and more advanced usage, please see
 :copyright: (c) 2021 by Ritvik Nag.
 :license: Apache 2.0, see LICENSE for more details.
 """
+
 __all__ = [
     # Force the linter to recognize that these are exports
     "JSONSerializable",

--- a/dataclass_witch/loaders.py
+++ b/dataclass_witch/loaders.py
@@ -63,6 +63,8 @@ from .type_def import (
     DefFactory,
     NoneType,
     JSONObject,
+    PyRequired,
+    PyNotRequired,
     M,
     N,
     T,
@@ -408,6 +410,11 @@ class LoadMixin(AbstractLoader, BaseLoadHook):
                         return UnionParser(
                             base_cls, extras, base_types, cls.get_parser_for_annotation
                         )
+
+                elif base_type in (PyRequired, PyNotRequired):
+                    # Given `Required[T]` or `NotRequired[T]`, we only need `T`
+                    ann_type = get_args(ann_type)[0]
+                    return cls.get_parser_for_annotation(ann_type, base_cls, extras)
 
                 elif issubclass(base_type, defaultdict):
                     load_hook = hooks[defaultdict]

--- a/dataclass_witch/type_def.py
+++ b/dataclass_witch/type_def.py
@@ -5,6 +5,8 @@ __all__ = [
     "PyDeque",
     "PyTypedDict",
     "PyTypedDicts",
+    "PyRequired",
+    "PyNotRequired",
     "FrozenKeys",
     "DefFactory",
     "NoneType",
@@ -139,6 +141,17 @@ except ImportError:
 
 PyTypedDicts.append(PyTypedDict)
 
+# Python 3.11 introduced `Required` and `NotRequired` wrappers for
+# `TypedDict` fields (PEP 655). Users of earlier Python versions may
+# import them from `typing_extensions`. However, they then need to
+# use `TypedDict` from `typing_extensions`, not from the standard
+# library.
+try:
+    from typing import Required as PyRequired
+    from typing import NotRequired as PyNotRequired
+except ImportError:
+    from typing_extensions import Required as PyRequired
+    from typing_extensions import NotRequired as PyNotRequired
 
 # Forward references can be either strings or explicit `ForwardRef` objects.
 # noinspection SpellCheckingInspection

--- a/dataclass_witch/utils/typing_compat.py
+++ b/dataclass_witch/utils/typing_compat.py
@@ -1,6 +1,7 @@
 """
 Utility module for checking generic types provided by the `typing` library.
 """
+
 import sys
 import types
 import typing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,12 @@ __all__ = [
     "data_file_path",
     "PY39_OR_ABOVE",
     "PY310_OR_ABOVE",
+    "PY310_OR_BELOW",
+    "PY311_OR_ABOVE",
     "Literal",
     "TypedDict",
+    "Required",
+    "NotRequired",
     "Annotated",
     "Deque",
 ]
@@ -23,6 +27,10 @@ PY39_OR_ABOVE = sys.version_info[:2] >= (3, 9)
 # Check if we are running Python 3.10+
 PY310_OR_ABOVE = sys.version_info[:2] >= (3, 10)
 
+# Check if we are running Python 3.11+
+PY311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
+PY310_OR_BELOW = not PY311_OR_ABOVE
+
 try:
     from typing import Literal
     from typing import TypedDict
@@ -33,6 +41,14 @@ except ImportError:
     from typing_extensions import TypedDict
     from typing_extensions import Annotated
     from typing_extensions import Deque
+
+# typing.Required and typing.NotRequired were introduced in Python 3.11
+if PY311_OR_ABOVE:
+    from typing import Required
+    from typing import NotRequired
+else:
+    from typing_extensions import Required
+    from typing_extensions import NotRequired
 
 
 def data_file_path(name: str) -> str:


### PR DESCRIPTION
This is a port of PR rnag/dataclass-wizard#125.
___

Previously, annotating a `TypedDict` field with one of the `Required` and `NotRequired` wrappers introduced in Python 3.11, the library would raise the following error:

> TypeError: issubclass() arg 1 must be a class

This pull request fixes that error by adding support for `Required` and `NotRequired`.

See also issue rnag/dataclass-wizard#121, part of which is addressed by this PR.
